### PR TITLE
Change NORMATIVE ID Key Licenses

### DIFF
--- a/abstract.html
+++ b/abstract.html
@@ -15,7 +15,7 @@
     and other GS1 ID Keys.  As trade communications becomes increasingly digital,
    GS1 is extending it's license system to provide digital licenses using <abbr title="World Wide Web Consortium">W3C</abbr>
    Verifiable Credentials (<abbr title="Verifiable Credentials">VCs</abbr> singular <abbr title="Verifiable Credential">VC</abbr>).  These
-   GS1 Licenses Credentials allow companies to prove their authority over their GS1 ID Keys and product data.
+   GS1 License Credentials allow companies to prove their authority over their GS1 ID Keys and product data.
    This document is intended for MO and MC <abbr title="Information Technology">IT</abbr> architects and developers
    who wish to understand and use GS1 License Credentials to issue trusted GS1 ID keys and verifiable product data.
  </p>

--- a/license_validation.html
+++ b/license_validation.html
@@ -43,7 +43,7 @@
                 <li><strong>PL</strong> MUST conform to the JSON schema located at <a target="_blank" rel="noopener noreferrer" href="https://id.gs1.org/vc/schema/v1/prefix">https://id.gs1.org/vc/schema/v1/prefix.</a></li>
                 <li><strong>PL</strong>  <code>Issuer</code> property MUST be a GS1 GO did:web or did:webvh.</li>
                 <li><strong>PL</strong> <code>licenseValue</code>  MUST be from two to seven numeric digits.<span class="todo">TODO add this rule to the schema</span></li>
-                <li><strong>PL</strong> <code>alternateLicenseValue</code> (if present) MUST <span class="todo">TODO this is complicated</span></li>
+                <li>If <strong>PL</strong> <code>alternateLicenseValue</code> is present,  <code>licenseValue</code> must end with <code>alternateLicenseValue</code>.</li>
             </ul>
         </section>
 
@@ -60,7 +60,7 @@
                 <li><strong>GL</strong> <code>licenseValue</code> MUST be between four and twelve numeric digits.<span class="todo">TODO add this rule to the schema</span></li>
                 <li><strong>EL</strong> <code>credentialSubject</code> <code>id</code>MUST match <strong>GL</strong> <code>issuer</code>.</li>
                 <li><strong>GL</strong> <code>licenseValue</code>  MUST begin with and MUST be at least one digit longer than the <strong>EL</strong>  <code>licenseValue</code>.</li>
-                <li><strong>GL</strong>  <code>alternateLicenseValue</code> (if present) MUST ...<span class="todo">TODO this is complicated</span></li>
+                <li>If <strong>PL</strong> <code>alternateLicenseValue</code> is present,  <code>licenseValue</code> must end with <code>alternateLicenseValue</code>.</li>
             </ul>
         </section>
 
@@ -73,7 +73,7 @@
                 <li><strong>EL</strong> MUST be a valid <a href="#license-validation">GS1 License Credential</a>.</li>
                 <li><strong>EL</strong> <code>credentialSubject</code> <code>id</code>MUST match <strong>IL</strong> <code>issuer</code>.</li>
                 <li><strong>IL</strong> <code>licenseValue</code> MUST begin with and MUST be at least one digit longer than the <strong>EL</strong> <code>licenseValue</code></li>
-                <li><strong>IL</strong>  <code>alternateLicenseValue</code> (if present) MUST ...<span class="todo">TODO this is complicated</span></li>
+                <li>If <strong>PL</strong> <code>alternateLicenseValue</code> is present,  <code>licenseValue</code> must end with <code>alternateLicenseValue</code>.</li>
             </ul>
         </section>
     </section>

--- a/licensing.html
+++ b/licensing.html
@@ -6,7 +6,7 @@
     <h2>GS1 License Credentials</h2>
     <p><a href='#GS1-Licenses'>GS1 Licensing</a> provides the root of trust for the globally unique
         trade identification systems.
-        GS1 Licenses Credentials are digital representations of the existing GS1 Licenses described in <a href="#GS1-Licenses"></a>.  These licenses
+        GS1 License Credentials are digital representations of the existing GS1 Licenses described in <a href="#GS1-Licenses"></a>.  These licenses
         can be verified by machines in <abbr title="Business to Business">B2B</abbr>
         transactions. Why might digital verification of GS1 Licenses be beneficial?</p>
     <ul class="orange-bullets">
@@ -280,34 +280,31 @@
         </section>
         <section id="License-values">
         <h3>licenseValue</h3>
-        <p>Every license credential includes a <code>licenseValue</code>. The license credential type is usually sufficient to
-        define, together with the <code>licenseValue</code>, the “space” or “range” of the GS1 identification system
-        granted to the licensee. The exception to this is any license credential that has to do with a GS1
-        ID Key, which requires an GS1 ID Key type as an additional qualifier.
-        For license credentials that have to do with prefixes, the license value is in normalized GS1 (i.e.,
-        non-U.P.C.) form. Where the license credential is within the U.P.C. range, the alternative license
-        value holds the U.P.C. form.
-        For license credentials that have to do with GS1 ID Keys, the license value is the ID Key,
-        including the check digit or check characters if applicable, and excluding the serial component if
-        applicable. When the license is specifically for a GTIN, the license value is the GTIN in its minimum
-        format: GTIN-8, GTIN-12, GTIN-13 (which must not start with a zero), or GTIN-14 (which must
-        start with indicator digit 9). Where the license credential is for a GTIN-8, GTIN-12, or GTIN-13, the
-        alternative license value is the GTIN normalized to 13 digits (by padding with zeros on the left) and
-        with the check digit removed (resulting in a 12-digit string); this value is used when verifying a
-        GTIN with indicator digit 1-8 against a license.</p>
+        <p>A GS1 License Credentials MUST includes a <code>licenseValue</code>.
+
+        <p>For <code>GS1PrefixLicenseCredential</code>, <code>GS18PrefixLicenseCredential</code>,
+            <code>GS1CompanyPrefixLicenseCredential</code>, and <code>DelegatedGS1PrefixLicenseCredential</code>
+            the <code>licenseValue</code> is the GS1 Prefix Or GCP as specified in
+            <a target="_blank" rel="noopener noreferrer" href="https://www.gs1.org/standards/barcodes-epcrfid-id-keys/gs1-general-specifications">General Specification Section 1.4</a>.<p>
+
+        <p>For <code>GS1IdentificationKeyLicenseCredential</code> and <code>DelegatedGS1IdentificationKeyLicenseCredential</code>
+         the <code>licenseValue</code> contains the licensed GS1 ID Key in the canonical form specified in <a target="_blank" rel="noopener noreferrer" href="https://ref.gs1.org/standards/digital-link/uri-syntax/">GS1 Digital Link Standard Section 4.5</a>.<p>
         </section>
 
         <section id="alternate-License-values">
         <h3>alternativeLicenseValue</h3>
-        <p>Alternative value of the license.
-        For most licenses, the alternative value of
-        the license is the bridge between the
-        U.P.C. system and the rest of the GS1
-        system: if the license value starts with
-        zero, then the alternative license value is
-        the same as the license value but without
-        the leading zero.</p>
-        <p><span class="todo">TODO</span> we need more language on what this is.</p>
+        <p>A GS1 License Credential MAY include an <code>alternativeLicenseValue</code> which bridges
+        the canonical representations to compact representations for encoding into different symbologies. Typically
+        this is the bridge between the U.P.C. or EAN system and the rest of the GS1 system.</p>
+
+        <p><code>GS1PrefixLicenseCredential</code>, <code>GS18PrefixLicenseCredential</code>,
+            <code>GS1CompanyPrefixLicenseCredential</code>, and <code>DelegatedGS1PrefixLicenseCredential</code>
+              MAY contain an  <code>alternativeLicenseValue</code> If the <code>licenseValue</code> starts with zero, then the <code>alternativeLicenseValue</code> is equilvalent to the <code>licenseValue</code> but without the leading zero.</p>
+
+        <p>For <code>GS1IdentificationKeyLicenseCredential</code> and <code>DelegatedGS1IdentificationKeyLicenseCredential</code>
+            the <code>alternativeLicenseValue</code> MAY contain the compact form of the ID Key with leading zeros removed.</p>
+
+         <p>For example when licensing an individual GTIN in the United States an <code>GS1IdentificationKeyLicenseCredential</code> would contains a 14-digit  <code>licenseValue</code> and a 12-digit <code>alternativeLicenseValue</code>, where the two values are different by two leading zeros.</p>
 
         </section>
 

--- a/overview.html
+++ b/overview.html
@@ -4,7 +4,7 @@
 </head>
 <body>
     <h2>Overview</h2>
-    <p>This section presents an overview of GS1 and key concepts that are required to understand and use the GS1 Licenses Credentials</p>
+    <p>This section presents an overview of GS1 and key concepts that are required to understand and use GS1 License Credentials</p>
     <section id="About-GS1">
         <h3>About GS1</h3>
 

--- a/samples/gtin8-id-key-license-sample.json
+++ b/samples/gtin8-id-key-license-sample.json
@@ -21,9 +21,9 @@
       "gs1:partyGLN": "0810159550000",
       "gs1:organizationName": "Healthy Tots"
     },
-    "extendsCredential": "https://id.gs1.org/vc/license/gs1_8_prefix/754",
-    "licenseValue": "07512345",
-    "alternativeLicenseValue": "00000007512345",
+    "extendsCredential": "https://id.gs1.org/vc/license/gs1_8_prefix/0000000751",
+    "licenseValue": "00000007512345",
+    "alternativeLicenseValue": "07512345",
     "identificationKeyType": "GTIN"
   },
   "credentialSchema": {

--- a/samples/id-key-license-sample.json
+++ b/samples/id-key-license-sample.json
@@ -21,9 +21,9 @@
       "gs1:partyGLN": "0810159550000",
       "gs1:organizationName": "Healthy Tots"
     },
-    "extendsCredential": "https://id.gs1.org/vc/license/gs1_prefix/08",
-    "licenseValue": "00198715637472",
-    "alternativeLicenseValue": "0198715637472",
+    "extendsCredential": "https://id.gs1.org/vc/license/gs1_prefix/00198",
+    "licenseValue": "00810159550111",
+    "alternativeLicenseValue": "810159550111",
     "identificationKeyType": "GTIN"
   },
   "credentialSchema": {

--- a/validating_keys.html
+++ b/validating_keys.html
@@ -29,10 +29,7 @@
                 <ul>
                     <li><strong>P</strong> MUST be a valid <a href="#license-validation">GS1 License Credential</a>.</li>
                     <li>The <code>issuer</code> of <strong>K</strong>  MUST match the subject of <strong>P</strong>.</li>
-                    <li><strong>PK</strong> MUST begin with (as a string) the <code>licenseValue</code> from <strong>P</strong>.
-                        <span class="todo">TODO</span>
-                        this isnt quite correct. For example a digital link always references the GTIN as 14 digits but the licenseValue could be from
-                        a GTIN 8 license credential in which case there are leading zeros.</li>
+                    <li><strong>PK</strong> MUST begin with (as a string) the <code>licenseValue</code> from <strong>P</strong>.</li>
                 </ul>
             <li>If <strong>D</strong> contains a GS1 Digital Link with primary Key <strong>PK</strong> and one or more key qualifiers:</li>
                 <ul>


### PR DESCRIPTION
NOTE:

This changed the definition from the original data model for the ID Key License Credential.

Its mostly for GTINs...

the licenseValue now contains the primary key as defined by Digital Link The alternativeLicenseValue now contains the compact form when applicable.