### PR TITLE
show the identifiation key type in all licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ View the document [here](https://gs1.github.io/GS1DigitalLicenses/).
 Its best to view this in a webserver since content is dynamic. I use
 
 ```
-python -m http.server 8000
+python cors_server.py
 ```
+
+I use the resource Override browser plugin and these settings to test locally
+
+* Source URL ```/https:\/\/gs1\.github\.io\/GS1DigitalLicenses\/(.*)/```
+* Destination URL ```http://127.0.0.1:8000/$1``
 
 # Generation
 

--- a/cors_server.py
+++ b/cors_server.py
@@ -1,0 +1,18 @@
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+class CORSRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        super().end_headers()
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.end_headers()
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("127.0.0.1", 8000), CORSRequestHandler)
+    print("Serving on http://127.0.0.1:8000")
+    server.serve_forever()
+

--- a/templates/gs1-sample-license-template.svg
+++ b/templates/gs1-sample-license-template.svg
@@ -42,8 +42,12 @@
   <text x="30" y="145" style="font: bold 13px sans-serif; fill: #333;">Alt License Value:</text>
   <text x="210" y="145" id="alt-license-value" style="font: 13px monospace; fill: #0057b8;">{{credentialSubject.alternativeLicenseValue}}</text>
 
+  <!-- Identification Key Type -->
+  <text x="30" y="165" style="font: bold 13px sans-serif; fill: #333;">Identification Key Type:</text>
+  <text x="210" y="165" id="identificationKeyType" style="font: 13px monospace; fill: #0057b8;">{{credentialSubject.identificationKeyType}}</text>
+
   <!-- Description block -->
-  <foreignObject x="30" y="165" width="530" height="110">
+  <foreignObject x="30" y="185" width="530" height="110">
     <body xmlns="http://www.w3.org/1999/xhtml">
       <p id="vc-description" style="
         font-family: sans-serif;


### PR DESCRIPTION
So the browser code was trying to show the identificationKeyType but it was removed from the template.  This browser code is really specific to these samples. not sure how we want to address, but this seems to fix things

NOTE: I already pushed updates to the JWTs that regenerated them.  